### PR TITLE
adds support for `ItemsPath` and `MaxConcurrency`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'j2119', '>=0.3.0'
+gem 'j2119', '>=0.4.0'
 gem 'rake', '>=12.3.2'
 gem 'rspec', '>=3.8.0'

--- a/data/StateMachine.j2119
+++ b/data/StateMachine.j2119
@@ -109,6 +109,8 @@ A Wait State MUST have only one of "Seconds", "SecondsPath", "Timestamp", and "T
 A Wait State MUST have a field named one of "Seconds", "SecondsPath", "Timestamp", or "TimestampPath".
 A Parallel State MUST have an object-array field named "Branches"; each element is a "Branch".
 A Map State MUST have an object field named "Iterator"; its value is a "Branch".
+A Map State MAY have a referencePath field named "ItemsPath".
+A Map State MAY have a numeric field named "MaxConcurrency".
 A Branch MUST have an object field named "States"; each field is a "State".
 A Branch MUST have a string field named "StartAt".
 A Branch MAY have a string field named "Comment".

--- a/lib/statelint.rb
+++ b/lib/statelint.rb
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 #!/usr/bin/env ruby
 
-$:.unshift("#{File.expand_path(File.dirname(__FILE__))}/../lib")
 require 'j2119'
 require 'statelint/state_node'
 

--- a/spec/state_node_spec.rb
+++ b/spec/state_node_spec.rb
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 #!/usr/bin/env ruby
 
-$:.unshift("#{File.expand_path(File.dirname(__FILE__))}/../lib")
 require 'json'
 require 'statelint/state_node'
 

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 #!/usr/bin/env ruby
 
-$:.unshift("#{File.expand_path(File.dirname(__FILE__))}/../lib")
 require 'json'
 require 'statelint'
 

--- a/statelint.gemspec
+++ b/statelint.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'statelint'
-  s.version     = '0.3.0'
+  s.version     = '0.4.1'
   s.summary     = "State Machine JSON validator"
   s.description = "Validates a JSON object representing a State Machine"
   s.authors     = ["Tim Bray"]
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.2'
 
-  s.add_runtime_dependency 'j2119', '>= 0.3.0'
+  s.add_runtime_dependency 'j2119', '~> 0.4', '>= 0.4.0'
 
   s.metadata = {
     'source_code_uri' => 'https://github.com/awslabs/statelint',


### PR DESCRIPTION
`Map` states allow two optional fields, `ItemsPath` and `MaxConcurrency`, which were being incorrectly
raised as errors when parsing state machines that made use of these fields.

- updates the _j2119_ specification to allow for these fields (fixes
  awslabs/statelint#29)
- cleans up warnings when building the gemspec by specifying the version
  of the `j2119` gem in a more constrained manner.
- updates `Gemfile` so that the version of `j2119` agrred with the
  version in the `gemspec`
- removed unnecessary `$LOAD_PATH` manipulation from all ruby files in the
  project (refs awslabs/statelint#20)